### PR TITLE
Added support for physical scancodes

### DIFF
--- a/addons/controller_icons/ControllerIcons.gd
+++ b/addons/controller_icons/ControllerIcons.gd
@@ -112,7 +112,10 @@ func _is_path_action(path):
 
 func _convert_event_to_path(event: InputEvent):
 	if event is InputEventKey:
-		return _convert_key_to_path(event.keycode)
+		# If this is a physical key, convert to localized scancode
+		if event.keycode == 0:
+			return _convert_key_to_path(DisplayServer.keyboard_get_keycode_from_physical(event.physical_keycode))
+		return _convert_key_to_path(event.physical_keycode)
 	elif event is InputEventMouseButton:
 		return _convert_mouse_button_to_path(event.button_index)
 	elif event is InputEventJoypadButton:


### PR DESCRIPTION
*(closes #19)*

Physical keys have separate scancodes, so their values weren't being considered.

If a physical key is used, it will convert the physical key to the user's locale (e.g. physical key **Q** displays **Q** on QWERTY and **A** on AZERTY)
![image](https://user-images.githubusercontent.com/6501975/212776073-28e5699c-42c2-43f8-b247-859c338b9bb8.png)
