### PR TITLE
Implement forcing icon type and expose raw InputEvent parsing

### DIFF
--- a/addons/controller_icons/ControllerIcons.gd
+++ b/addons/controller_icons/ControllerIcons.gd
@@ -79,7 +79,6 @@ func _input(event: InputEvent):
 				input_type = InputType.CONTROLLER
 	if input_type != _last_input_type:
 		_set_last_input_type(input_type)
-		#print("Input changed to " + str(input_type) + "! Joy name is: ", Input.get_joy_name(0), " with GUID ", Input.get_joy_guid(0))
 
 func _add_custom_input_action(input_action: String, data: Dictionary):
 	_custom_input_actions[input_action] = data["events"]
@@ -88,8 +87,10 @@ func refresh():
 	# All it takes is to signal icons to refresh paths
 	emit_signal("input_type_changed", _last_input_type)
 
-func parse_path(path: String) -> Texture:
-	var root_paths := _expand_path(path)
+func parse_path(path: String, input_type: int = _last_input_type) -> Texture:
+	if typeof(input_type) == TYPE_NIL:
+		return null
+	var root_paths := _expand_path(path, input_type)
 	for root_path in root_paths:
 		if not _cached_icons.has(root_path):
 			if _load_icon(root_path):
@@ -97,7 +98,26 @@ func parse_path(path: String) -> Texture:
 		return _cached_icons[root_path]
 	return null
 
-func _expand_path(path: String) -> Array:
+func parse_event(event: InputEvent) -> Texture:
+	var path = _convert_event_to_path(event)
+	if path.is_empty():
+		return null
+
+	var base_paths := [
+		_settings.custom_asset_dir + "/",
+		"res://addons/controller_icons/assets/"
+	]
+	for base_path in base_paths:
+		if base_path.is_empty():
+			continue
+		base_path += path + ".png"
+		if not _cached_icons.has(base_path):
+			if _load_icon(base_path):
+				continue
+		return _cached_icons[base_path]
+	return null
+
+func _expand_path(path: String, input_type: int) -> Array:
 	var paths := []
 	var base_paths := [
 		_settings.custom_asset_dir + "/",
@@ -107,7 +127,7 @@ func _expand_path(path: String) -> Array:
 		if base_path.is_empty():
 			continue
 		if _is_path_action(path):
-			var event = _get_matching_event(path)
+			var event = _get_matching_event(path, input_type)
 			if event:
 				base_path += _convert_event_to_path(event)
 		elif path.substr(0, path.find("/")) == "joypad":
@@ -126,7 +146,7 @@ func _convert_event_to_path(event: InputEvent):
 		# If this is a physical key, convert to localized scancode
 		if event.keycode == 0:
 			return _convert_key_to_path(DisplayServer.keyboard_get_keycode_from_physical(event.physical_keycode))
-		return _convert_key_to_path(event.physical_keycode)
+		return _convert_key_to_path(event.keycode)
 	elif event is InputEventMouseButton:
 		return _convert_mouse_button_to_path(event.button_index)
 	elif event is InputEventJoypadButton:
@@ -402,7 +422,7 @@ func _convert_joypad_motion_to_path(axis: int):
 			return ""
 	return Mapper._convert_joypad_path(path, _settings.joypad_fallback)
 
-func _get_matching_event(path: String):
+func _get_matching_event(path: String, input_type: int):
 	var events : Array
 	if _custom_input_actions.has(path):
 		events = _custom_input_actions[path]
@@ -412,10 +432,10 @@ func _get_matching_event(path: String):
 	for event in events:
 		match event.get_class():
 			"InputEventKey", "InputEventMouse", "InputEventMouseMotion", "InputEventMouseButton":
-				if _last_input_type == InputType.KEYBOARD_MOUSE:
+				if input_type == InputType.KEYBOARD_MOUSE:
 					return event
 			"InputEventJoypadButton", "InputEventJoypadMotion":
-				if _last_input_type == InputType.CONTROLLER:
+				if input_type == InputType.CONTROLLER:
 					return event
 	return null
 

--- a/addons/controller_icons/objects/Button.gd
+++ b/addons/controller_icons/objects/Button.gd
@@ -6,11 +6,19 @@ class_name ControllerButton
 	set(_path):
 		path = _path
 		if is_inside_tree():
-			icon = ControllerIcons.parse_path(path)
-			
+			if force_type > 0:
+				icon = ControllerIcons.parse_path(path, force_type - 1)
+			else:
+				icon = ControllerIcons.parse_path(path)
+
 @export_enum("Both", "Keyboard/Mouse", "Controller") var show_only : int = 0:
 	set(_show_only):
 		show_only = _show_only
+		_on_input_type_changed(ControllerIcons._last_input_type)
+
+@export_enum("None", "Keyboard/Mouse", "Controller") var force_type : int = 0:
+	set(_force_type):
+		force_type = _force_type
 		_on_input_type_changed(ControllerIcons._last_input_type)
 
 func _ready():

--- a/addons/controller_icons/objects/Sprite.gd
+++ b/addons/controller_icons/objects/Sprite.gd
@@ -6,11 +6,19 @@ class_name ControllerSprite2D
 	set(_path):
 		path = _path
 		if is_inside_tree():
-			texture = ControllerIcons.parse_path(path)
-			
+			if force_type > 0:
+				texture = ControllerIcons.parse_path(path, force_type - 1)
+			else:
+				texture = ControllerIcons.parse_path(path)
+
 @export_enum("Both", "Keyboard/Mouse", "Controller") var show_only : int = 0:
 	set(_show_only):
 		show_only = _show_only
+		_on_input_type_changed(ControllerIcons._last_input_type)
+
+@export_enum("None", "Keyboard/Mouse", "Controller") var force_type : int = 0:
+	set(_force_type):
+		force_type = _force_type
 		_on_input_type_changed(ControllerIcons._last_input_type)
 
 func _ready():

--- a/addons/controller_icons/objects/Sprite3D.gd
+++ b/addons/controller_icons/objects/Sprite3D.gd
@@ -6,11 +6,19 @@ class_name ControllerSprite3D
 	set(_path):
 		path = _path
 		if is_inside_tree():
-			texture = ControllerIcons.parse_path(path)
-			
+			if force_type > 0:
+				texture = ControllerIcons.parse_path(path, force_type - 1)
+			else:
+				texture = ControllerIcons.parse_path(path)
+
 @export_enum("Both", "Keyboard/Mouse", "Controller") var show_only := 0:
 	set(_show_only):
 		show_only = _show_only
+		_on_input_type_changed(ControllerIcons._last_input_type)
+
+@export_enum("None", "Keyboard/Mouse", "Controller") var force_type : int = 0:
+	set(_force_type):
+		force_type = _force_type
 		_on_input_type_changed(ControllerIcons._last_input_type)
 
 func _ready():

--- a/addons/controller_icons/objects/TextureRect.gd
+++ b/addons/controller_icons/objects/TextureRect.gd
@@ -6,13 +6,21 @@ class_name ControllerTextureRect
 	set(_path):
 		path = _path
 		if is_inside_tree():
-			texture = ControllerIcons.parse_path(path)
-		
+			if force_type > 0:
+				texture = ControllerIcons.parse_path(path, force_type - 1)
+			else:
+				texture = ControllerIcons.parse_path(path)
+
 @export_enum("Both", "Keyboard/Mouse", "Controller") var show_only : int = 0:
 	set(_show_only):
 		show_only = _show_only
 		_on_input_type_changed(ControllerIcons._last_input_type)
-	
+
+@export_enum("None", "Keyboard/Mouse", "Controller") var force_type : int = 0:
+	set(_force_type):
+		force_type = _force_type
+		_on_input_type_changed(ControllerIcons._last_input_type)
+
 @export var max_width : int = 40:
 	set(_max_width):
 		max_width = _max_width


### PR DESCRIPTION
Icons can now always show a specific type independent of the current input method:
![image](https://user-images.githubusercontent.com/6501975/213301967-1fe4a3bb-b872-4241-9cf0-5cdc9ab0c7ba.png)
Also custom `InputEvent`s can now also be parsed through a new `parse_event` function

Closes #22 