### PR TITLE
Set controller to fallback on editor

### DIFF
--- a/addons/controller_icons/Mapper.gd
+++ b/addons/controller_icons/Mapper.gd
@@ -31,6 +31,11 @@ func _convert_joypad_path(path: String, fallback) -> String:
 			return ""
 
 func _get_joypad_type(fallback):
+	# If on editor, default to fallback always, to avoid editing scene
+	# files on controller reload
+	if Engine.is_editor_hint():
+		return fallback
+
 	var controller_name = Input.get_joy_name(0)
 	if "Luna Controller" in controller_name:
 		return ControllerSettings.Devices.LUNA


### PR DESCRIPTION
When running in editor/tool mode, the controller type will always default to the set fallback. This stops scene changes on source files when a controller is plugged in or not.

Fixes #37 