### PR TITLE
Fix #50 - Remove JoyAxis enum from JoyButton mapping

### DIFF
--- a/addons/controller_icons/ControllerIcons.gd
+++ b/addons/controller_icons/ControllerIcons.gd
@@ -425,10 +425,6 @@ func _convert_joypad_button_to_path(button_index: int):
 			path = "joypad/lb"
 		JOY_BUTTON_RIGHT_SHOULDER:
 			path = "joypad/rb"
-		JOY_AXIS_TRIGGER_LEFT:
-			path = "joypad/lt"
-		JOY_AXIS_TRIGGER_RIGHT:
-			path = "joypad/rt"
 		JOY_BUTTON_LEFT_STICK:
 			path = "joypad/l_stick_click"
 		JOY_BUTTON_RIGHT_STICK:


### PR DESCRIPTION
Removed JoyAxis from the JoyButton mapping. The JoyAxis buttons are mapped by the other method '_convert_joypad_motion_to_path'