### PR TITLE
queue_free mapper on exit

### DIFF
--- a/addons/controller_icons/ControllerIcons.gd
+++ b/addons/controller_icons/ControllerIcons.gd
@@ -24,6 +24,9 @@ func _enter_tree():
 	if Engine.is_editor_hint():
 		_parse_input_actions()
 
+func _exit_tree():
+	Mapper.queue_free()
+
 func _parse_input_actions():
 	# Default actions will be the builtin editor actions when
 	# the script is at editor ("tool") level. To pickup more


### PR DESCRIPTION
Without this change, on exit you'll see these errors from Godot.

```
WARNING: ObjectDB instances leaked at exit (run with --verbose for details).
     at: cleanup (core/object/object.cpp:2045)
ERROR: Resources still in use at exit (run with --verbose for details).
   at: clear (core/io/resource.cpp:489)
```

Adding the lines in the PR causes it to be freed when the script is exiting the tree (in this case because the game is being closed), and avoids that error.