### PR TITLE
Fix Command key not showing on macOS

### DIFF
--- a/addons/controller_icons/ControllerIcons.gd
+++ b/addons/controller_icons/ControllerIcons.gd
@@ -307,7 +307,7 @@ func _convert_key_to_path(scancode: int):
 			return "key/ctrl"
 		KEY_META:
 			match OS.get_name():
-				"OSX":
+				"macOS":
 					return "key/command"
 				_:
 					return "key/meta"


### PR DESCRIPTION
Godot changed macOS's `OS.get_name()` from `OSX` to `macOS` in Godot 4.

Fixes #53 