### PR TITLE
Add deprecation notice to 3.x version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,18 @@
-<img src="https://raw.githubusercontent.com/Ev1lbl0w/controller_icons/master/icon.png" width=15%>
+<img src="https://raw.githubusercontent.com/rsubtil/controller_icons/3.x/icon.png" width=15%>
 
 # Controller Icons
 
 Provides icons for all major controllers and keyboard/mouse actions, with an automatic icon remapping system.
 
 > This is the Godot 3.x version. For the Godot 4.x version, check the [master branch](https://github.com/rsubtil/controller_icons/tree/master)
+
+> [!WARNING]
+> **This version (v2.x.x) is the last major update for the 3.x version. This branch will only receive small features and critical bug fixes from now on.**
+>
+> With the internal refactor from v3.0.0, the addon changed significantly from previous versions. Thus, no further development will be done in the 3.x branch due to various reasons:
+> - Version 3.0.0 does not change any behavior from 2.x.x, so there's no major benefit to end-users in porting these new changes.
+> - The internal refactor will allow to implement future features more easily, which are significantly harder to do with Godot 3.
+> - Godot 4 adoption has been faster than expected, with [>75% of Godot users](https://docs.google.com/forms/d/e/1FAIpQLSeXRE1nF64PUilO6fA7Pevh2lWukJtpdBvc2_A3fGfuciy-gQ/viewanalytics) already having moved on to Godot 4.
 
 ## Features
 
@@ -27,12 +35,12 @@ Provides icons for all major controllers and keyboard/mouse actions, with an aut
 	- PlayStation 3
 	- PlayStation 4
 	- PlayStation 5
-	- Nintendo Switch Controller
-	- Nintendo Switch Joy-Con
+	- Nintendo Switch Controller / Joy-Con
 	- Steam Controller
 	- Steam Deck
 	- Amazon Luna
 	- Google Stadia
+	- OUYA
 
 ## Installation
 
@@ -59,4 +67,4 @@ The addon is licensed under the MIT license. Full details at [LICENSE](LICENSE).
 
 The controller assets are [Xelu's FREE Controllers & Keyboard PROMPTS](https://thoseawesomeguys.com/prompts/), made by Nicolae (XELU) Berbece and under Creative Commons 0 _(CC0)_.
 
-The icon was designed by [@adambelis](https://github.com/adambelis) ([#5](https://github.com/Ev1lbl0w/controller_icons/pull/5)) and is under Create Commons 0 _(CC0)_. It uses the [Godot's logo](https://github.com/godotengine/godot/blob/master/icon.svg) which is under Creative Commons Attribution 4.0 International License _(CC-BY-4.0 International)_
+The icon was designed by [@adambelis](https://github.com/adambelis) ([#5](https://github.com/rsubtil/controller_icons/pull/5)) and is under Create Commons 0 _(CC0)_. It uses the [Godot's logo](https://github.com/godotengine/godot/blob/master/icon.svg) which is under Creative Commons Attribution 4.0 International License _(CC-BY-4.0 International)_


### PR DESCRIPTION
The v3.0.0 refactor is quite large, and porting such work to the `3.x` version is not worth. The amount of work needed to maintain 2 versions would be too much for me to justify taking into account that Godot 3 is quickly being replaced by Godot 4, and newer planned features would be harder to implement in Godot 3.

Thus, for Godot 3, the addon will remain in the version 2.x.x, only receiving small features and  critical bug-fixes. 