### PR TITLE
Rename inner editor classes with addon prefix

### DIFF
--- a/addons/controller_icons/objects/ControllerIconEditorInspector.gd
+++ b/addons/controller_icons/objects/ControllerIconEditorInspector.gd
@@ -4,7 +4,7 @@ var path_selector := preload("res://addons/controller_icons/objects/ControllerIc
 
 var editor_interface : EditorInterface
 
-class TexturePreview:
+class ControllerIcons_TexturePreview:
 	var n_root: MarginContainer
 	var n_background: TextureRect
 	var n_texture: TextureRect
@@ -40,13 +40,13 @@ class TexturePreview:
 	func get_root():
 		return n_root
 
-var preview: TexturePreview
+var preview: ControllerIcons_TexturePreview
 
 func _can_handle(object: Object) -> bool:
 	return object is ControllerIconTexture
 
 func _parse_begin(object: Object) -> void:
-	preview = TexturePreview.new(editor_interface)
+	preview = ControllerIcons_TexturePreview.new(editor_interface)
 	add_custom_control(preview.get_root())
 	
 	var icon := object as ControllerIconTexture

--- a/addons/controller_icons/objects/path_selection/InputActionSelector.gd
+++ b/addons/controller_icons/objects/path_selection/InputActionSelector.gd
@@ -7,7 +7,7 @@ signal done
 @onready var n_builtin_action_button := %BuiltinActionButton
 @onready var n_tree := %Tree
 
-class Item:
+class ControllerIcons_Item:
 	func _init(tree: Tree, root: TreeItem, path: String, is_default: bool):
 		self.is_default = is_default
 		self.filtered = true
@@ -45,13 +45,13 @@ class Item:
 		set(_filtered):
 			filtered = _filtered
 			_query_visibility()
-	
+
 	func _query_visibility():
 		if is_instance_valid(tree_item):
 			tree_item.visible = show_default and filtered
 
 var root : TreeItem
-var items : Array[Item]
+var items : Array[ControllerIcons_Item]
 
 func populate(editor_interface: EditorInterface) -> void:
 	# Clear
@@ -81,7 +81,7 @@ func populate(editor_interface: EditorInterface) -> void:
 	# Map with all input actions
 	root = n_tree.create_item()
 	for data in ControllerIcons._custom_input_actions:
-		var child := Item.new(n_tree, root, data, data in default_actions)
+		var child := ControllerIcons_Item.new(n_tree, root, data, data in default_actions)
 		items.push_back(child)
 
 	set_default_actions_visibility(n_builtin_action_button.button_pressed)
@@ -95,7 +95,7 @@ func get_icon_path() -> String:
 func set_default_actions_visibility(display: bool):
 	# UPGRADE: In Godot 4.2, for-loop variables can be
 	# statically typed:
-	# for item:Item in items:
+	# for item:ControllerIcons_Item in items:
 	for item in items:
 		item.show_default = display or not item.is_default
 
@@ -114,7 +114,7 @@ func _on_tree_item_activated() -> void:
 func _on_name_filter_text_changed(new_text: String):
 	# UPGRADE: In Godot 4.2, for-loop variables can be
 	# statically typed:
-	# for item:Item in items:
+	# for item:ControllerIcons_Item in items:
 	for item in items:
 		var filtered := true if new_text.is_empty() else item.tree_item.get_text(0).findn(new_text) != -1
 		item.filtered = filtered

--- a/addons/controller_icons/objects/path_selection/SpecificPathSelector.gd
+++ b/addons/controller_icons/objects/path_selection/SpecificPathSelector.gd
@@ -7,13 +7,13 @@ signal done
 @onready var n_base_asset_names := %BaseAssetNames
 @onready var n_assets_container := %AssetsContainer
 
-var _last_pressed_icon : Icon
+var _last_pressed_icon : ControllerIcons_Icon
 var _last_pressed_timestamp : int
 
 var color_text_enabled : Color
 var color_text_disabled : Color
 
-class Icon:
+class ControllerIcons_Icon:
 	static var group := ButtonGroup.new()
 
 	func _init(category: String, path: String):
@@ -114,7 +114,7 @@ func create_icon(category: String, path: String):
 	if button_nodes[map_category].has(filename): return
 
 	var icon_path = ("" if category.is_empty() else category + "/") + path.get_file().get_basename()
-	var icon := Icon.new(map_category, icon_path)
+	var icon := ControllerIcons_Icon.new(map_category, icon_path)
 	button_nodes[map_category][filename] = icon
 	n_assets_container.add_child(icon.button)
 	icon.button.pressed.connect(func():
@@ -129,7 +129,7 @@ func create_icon(category: String, path: String):
 	)
 
 func get_icon_path() -> String:
-	var button := Icon.group.get_pressed_button()
+	var button := ControllerIcons_Icon.group.get_pressed_button()
 	if button:
 		return button.icon.path
 	return ""
@@ -141,14 +141,14 @@ func grab_focus() -> void:
 func _on_base_asset_names_item_selected():
 	var selected : TreeItem = n_base_asset_names.get_selected()
 	if not selected: return
-	
+
 	var category := selected.get_text(0)
 	if not button_nodes.has(category): return
-	
+
 	# UPGRADE: In Godot 4.2, for-loop variables can be
 	# statically typed:
 	# for key:String in button_nodes.keys():
-	# 	for icon:Icon in button_nodes[key].values():
+	# 	for icon:ControllerIcon_Icon in button_nodes[key].values():
 	for key in button_nodes.keys():
 		for icon in button_nodes[key].values():
 			icon.selected = key == category


### PR DESCRIPTION
Closes #74.

Inner classes can clash with existing `class_name` global classes. Using simple names like `Icon`, `Item` and `TexturePreview` is prone to causing clashes, so a `ControllerIcons_` prefix was added to mitigate this.

Since these are internal classes for the path picker utility, there are no compatibility/breakage issues to tackle.