### PR TITLE
Fix ControllerIconsTexture icon not marked as editor icon

### DIFF
--- a/addons/controller_icons/objects/controller_texture_icon.svg.import
+++ b/addons/controller_icons/objects/controller_texture_icon.svg.import
@@ -5,6 +5,7 @@ type="CompressedTexture2D"
 uid="uid://d4cwx85k03lt7"
 path="res://.godot/imported/controller_texture_icon.svg-c7feb059f1c41a49e9f62f5b03706d01.ctex"
 metadata={
+"has_editor_variant": true,
 "vram_texture": false
 }
 
@@ -33,5 +34,5 @@ process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1
 svg/scale=1.0
-editor/scale_with_editor_scale=false
-editor/convert_colors_with_editor_theme=false
+editor/scale_with_editor_scale=true
+editor/convert_colors_with_editor_theme=true


### PR DESCRIPTION
Enables editor-only properties on import. Fixes the icon becoming invisible in light themes, and not following editor scaling.