### PR TITLE
Remove old await hack when switching input methods

### DIFF
--- a/addons/controller_icons/ControllerIcons.gd
+++ b/addons/controller_icons/ControllerIcons.gd
@@ -108,12 +108,8 @@ func _ready():
 func _on_joy_connection_changed(device, connected):
 	if device == 0:
 		if connected:
-			# An await is required, otherwise a deadlock happens
-			await get_tree().process_frame
 			_set_last_input_type(InputType.CONTROLLER)
 		else:
-			# An await is required, otherwise a deadlock happens
-			await get_tree().process_frame
 			_set_last_input_type(InputType.KEYBOARD_MOUSE)
 
 func _input(event: InputEvent):


### PR DESCRIPTION
Closes #71.

Now that the minimum version was bumped to 4.1.2, this issue was fixed in the engine, and thus this hack is no longer required.