### PR TITLE
Support simple keyboard shortcuts

### DIFF
--- a/addons/controller_icons/Settings.gd
+++ b/addons/controller_icons/Settings.gd
@@ -18,23 +18,35 @@ enum Devices {
 	STEAM_DECK
 }
 
+## General addon settings
+@export_subgroup("General")
+
 ## Controller type to fallback to if automatic
 ## controller detection fails
 @export var joypad_fallback : Devices = Devices.XBOX360
 
-# Controller deadzone for triggering an icon remap when input
-# is analogic (movement sticks or triggers)
+## Controller deadzone for triggering an icon remap when input
+## is analogic (movement sticks or triggers)
 @export_range(0.0, 1.0) var joypad_deadzone : float = 0.5
 
-# Allow mouse movement to trigger an icon remap
+## Allow mouse movement to trigger an icon remap
 @export var allow_mouse_remap : bool = true
 
-# Minimum mouse "instantaneous" movement for
-# triggering an icon remap
+## Minimum mouse "instantaneous" movement for
+## triggering an icon remap
 @export_range(0, 10000) var mouse_min_movement : int = 200
 
-# Custom asset lookup folder for custom icons
+## Settings related to advanced custom assets usage and remapping
+@export_subgroup("Custom assets")
+
+## Custom asset lookup folder for custom icons
 @export_dir var custom_asset_dir : String = ""
 
-# Custom generic joystick mapper script
+## Custom generic joystick mapper script
 @export var custom_mapper : Script
+
+## Custom settings related to any text rendering required on prompts
+@export_subgroup("Text Rendering")
+
+## Custom LabelSettings. If unset, uses engine default settings.
+@export var custom_label_settings : LabelSettings

--- a/addons/controller_icons/objects/path_selection/InputActionSelector.gd
+++ b/addons/controller_icons/objects/path_selection/InputActionSelector.gd
@@ -21,15 +21,10 @@ class ControllerIcons_Item:
 		controller_icon_joy.path = path
 		controller_icon_joy.force_type = 2
 
-		tree_item.set_icon_max_width(1, 48)
-		tree_item.set_icon_max_width(2, 48)
-		if controller_icon_key._texture and controller_icon_joy._texture:
-			tree_item.set_icon(1, controller_icon_key)
-			tree_item.set_icon(2, controller_icon_joy)
-		elif controller_icon_key._texture:
-			tree_item.set_icon(2, controller_icon_key)
-		elif controller_icon_joy._texture:
-			tree_item.set_icon(2, controller_icon_joy)
+		tree_item.set_icon_max_width(1, 48 * controller_icon_key._textures.size())
+		tree_item.set_icon_max_width(2, 48 * controller_icon_key._textures.size())
+		tree_item.set_icon(1, controller_icon_key)
+		tree_item.set_icon(2, controller_icon_joy)
 
 	var is_default : bool
 	var tree_item : TreeItem


### PR DESCRIPTION
Closes #70.

Input actions with embedded modifiers (ctrl, shift, alt, meta/command) now show those modifiers properly, thanks to some basic text rendering.
![image](https://github.com/rsubtil/controller_icons/assets/6501975/0f8f5526-84f0-45b6-ad06-c60b867a196b)
`LabelSettings` properties were added both globally in the plugin settings, and per each texture icon. Text rendering is very basic nevertheless, but all properties from `LabeLSettings` work as expected (size, color, outline, shadow, etc...)

This lays the foundation for future planned features, such as https://github.com/rsubtil/controller_icons/issues/72 and https://github.com/rsubtil/controller_icons/issues/18.

Additionaly:
- Added categories to plugin settings, for easier organization
- Removed handling of icons in Icon Action selector UI when icon has only keyboard or joypad icon. With the new multi-key prompts, it looked confusing and unapealling. In the future when #18 is implemented, this will be fixed properly.