### PR TITLE
Fix Multithreaded Scene Loading

### DIFF
--- a/addons/controller_icons/assets/steamdeck/dpad_right.png.import
+++ b/addons/controller_icons/assets/steamdeck/dpad_right.png.import
@@ -3,26 +3,25 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://ccjjrpx72dn2r"
-path.s3tc="res://.godot/imported/dpad_right.png-828c1fa323dfa47ac18628cf2c8ec764.s3tc.ctex"
+path="res://.godot/imported/dpad_right.png-828c1fa323dfa47ac18628cf2c8ec764.ctex"
 metadata={
-"imported_formats": ["s3tc_bptc"],
-"vram_texture": true
+"vram_texture": false
 }
 
 [deps]
 
 source_file="res://addons/controller_icons/assets/steamdeck/dpad_right.png"
-dest_files=["res://.godot/imported/dpad_right.png-828c1fa323dfa47ac18628cf2c8ec764.s3tc.ctex"]
+dest_files=["res://.godot/imported/dpad_right.png-828c1fa323dfa47ac18628cf2c8ec764.ctex"]
 
 [params]
 
-compress/mode=2
+compress/mode=0
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
 compress/normal_map=0
 compress/channel_pack=0
-mipmaps/generate=true
+mipmaps/generate=false
 mipmaps/limit=-1
 roughness/mode=0
 roughness/src_normal=""
@@ -32,4 +31,4 @@ process/normal_map_invert_y=false
 process/hdr_as_srgb=false
 process/hdr_clamp_exposure=false
 process/size_limit=0
-detect_3d/compress_to=0
+detect_3d/compress_to=1

--- a/addons/controller_icons/objects/ControllerIconTexture.gd
+++ b/addons/controller_icons/objects/ControllerIconTexture.gd
@@ -172,7 +172,7 @@ func _load_texture_path_main_thread():
 	_reload_resource()
 
 func _load_texture_path():
-	_load_texture_path_main_thread().call_deferred()
+	_load_texture_path_main_thread.call_deferred()
 
 func _init():
 	ControllerIcons.input_type_changed.connect(_on_input_type_changed)

--- a/addons/controller_icons/objects/ControllerIconTexture.gd
+++ b/addons/controller_icons/objects/ControllerIconTexture.gd
@@ -172,7 +172,11 @@ func _load_texture_path_main_thread():
 	_reload_resource()
 
 func _load_texture_path():
-	_load_texture_path_main_thread.call_deferred()
+	# Ensure loading only occurs on the main thread
+	if OS.get_thread_caller_id() != OS.get_main_thread_id():
+		_load_texture_path_main_thread.call_deferred()
+	else:
+		_load_texture_path_main_thread()
 
 func _init():
 	ControllerIcons.input_type_changed.connect(_on_input_type_changed)

--- a/addons/controller_icons/objects/ControllerIconTexture.gd
+++ b/addons/controller_icons/objects/ControllerIconTexture.gd
@@ -160,7 +160,7 @@ func _reload_resource():
 	_dirty = true
 	emit_changed()
 
-func _load_texture_path():
+func _load_texture_path_main_thread():
 	var textures : Array[Texture2D] = []
 	if ControllerIcons.is_node_ready() and _can_be_shown():
 		var input_type = ControllerIcons._last_input_type if force_type == ForceType.NONE else force_type - 1
@@ -170,6 +170,9 @@ func _load_texture_path():
 		textures.append(ControllerIcons.parse_path(path, input_type))
 	_textures = textures
 	_reload_resource()
+
+func _load_texture_path():
+	_load_texture_path_main_thread().call_deferred()
 
 func _init():
 	ControllerIcons.input_type_changed.connect(_on_input_type_changed)


### PR DESCRIPTION
Hi!

I hope you don't mind, but I noticed that when loading scenes from threads that contain ControllerIcon textures I would get crashes. (https://docs.godotengine.org/en/stable/tutorials/io/background_loading.html)

This PR fixes the crash by ensuring the texture load happens on the main thread.

I also updated the import file for steamdeck dpad_right to match the other import files.