### PR TITLE
move add/remove Autoload to enable/disable plugin

### DIFF
--- a/addons/controller_icons/plugin.gd
+++ b/addons/controller_icons/plugin.gd
@@ -3,13 +3,17 @@ extends EditorPlugin
 
 var inspector_plugin : EditorInspectorPlugin
 
+func _enable_plugin():
+	add_autoload_singleton("ControllerIcons", "res://addons/controller_icons/ControllerIcons.gd")
+
+func _disable_plugin():
+	remove_autoload_singleton("ControllerIcons")
+
 func _enter_tree():
 	inspector_plugin = preload("res://addons/controller_icons/objects/ControllerIconEditorInspector.gd").new()
 	inspector_plugin.editor_interface = get_editor_interface()
 
-	add_autoload_singleton("ControllerIcons", "res://addons/controller_icons/ControllerIcons.gd")
 	add_inspector_plugin(inspector_plugin)
 
 func _exit_tree():
 	remove_inspector_plugin(inspector_plugin)
-	remove_autoload_singleton("ControllerIcons")


### PR DESCRIPTION
Hi!

I made it so the Autoload is being added when the plugin is enabled and removed when disabled instead of every time Godot opens/closes.

This fixes the error messages printed in the console every time Godot starts (unfortunately, the errors still remain if the plugin is disabled) and stops the Autoload from moving to the bottom of the list by itself

Side effect: users who update from a previous version will have to disable and re-enable the plugin once.