### PR TITLE
Fix loading icons from another thread and issue with call_deferred no…

### DIFF
--- a/addons/controller_icons/ControllerIcons.gd
+++ b/addons/controller_icons/ControllerIcons.gd
@@ -159,7 +159,7 @@ func _test_mouse_velocity(relative_vec: Vector2):
 	_mouse_velocity += abs(relative_vec.x) + abs(relative_vec.y)
 	return _mouse_velocity / _MOUSE_VELOCITY_DELTA > _settings.mouse_min_movement
 
-func push_reload_icon_texture(icon_texture: ControllerIconTexture) -> void:
+func push_reload_icon_texture(icon_texture) -> void:
 	_reload_icon_textures_mutex.lock()
 
 	if not icon_texture in _reload_icon_textures_list:

--- a/addons/controller_icons/objects/ControllerIconTexture.gd
+++ b/addons/controller_icons/objects/ControllerIconTexture.gd
@@ -160,23 +160,12 @@ func _reload_resource():
 	_dirty = true
 	emit_changed()
 
-func _load_texture_path_main_thread():
-	var textures : Array[Texture2D] = []
-	if ControllerIcons.is_node_ready() and _can_be_shown():
-		var input_type = ControllerIcons._last_input_type if force_type == ForceType.NONE else force_type - 1
-		if ControllerIcons.get_path_type(path) == ControllerIcons.PathType.INPUT_ACTION:
-			var event := ControllerIcons.get_matching_event(path, input_type)
-			textures.append_array(ControllerIcons.parse_event_modifiers(event))
-		textures.append(ControllerIcons.parse_path(path, input_type))
-	_textures = textures
+func set_textures(textures : Array[Texture2D])->void:
+	_textures = textures if ControllerIcons.is_node_ready() and _can_be_shown() else []
 	_reload_resource()
-
+	
 func _load_texture_path():
-	# Ensure loading only occurs on the main thread
-	if OS.get_thread_caller_id() != OS.get_main_thread_id():
-		_load_texture_path_main_thread.call_deferred()
-	else:
-		_load_texture_path_main_thread()
+	ControllerIcons.push_reload_icon_texture(self)
 
 func _init():
 	ControllerIcons.input_type_changed.connect(_on_input_type_changed)


### PR DESCRIPTION
`call_deferred` does not work from _init calls. Instead it directly calls the function: this may be new behaviour in Godot 4.3b2, and is also observed in 4.3b3.

The solution presented is more robust, as it implements a mutex protected list that is processed when reloads of textures are requested.

 