### PR TITLE
Use icons of the most recently used controller

### DIFF
--- a/addons/controller_icons/ControllerIcons.gd
+++ b/addons/controller_icons/ControllerIcons.gd
@@ -75,7 +75,7 @@ var _builtin_keys := [
 func _set_last_input_type(__last_input_type, __last_controller):
 	_last_input_type = __last_input_type
 	_last_controller = __last_controller
-	emit_signal("input_type_changed", _last_input_type, __last_controller)
+	emit_signal("input_type_changed", _last_input_type, _last_controller)
 
 func _enter_tree():
 	if Engine.is_editor_hint():
@@ -265,8 +265,10 @@ func get_matching_event(path: String, input_type: InputType = _last_input_type, 
 					return event
 			"InputEventJoypadButton", "InputEventJoypadMotion":
 				if input_type == InputType.CONTROLLER:
+					# Use the first device specific mapping if there is one.
 					if event.device == controller:
 						return event
+					# Otherwise ignore the device and use the first mapping.
 					elif fallback == null:
 						fallback = event
 

--- a/addons/controller_icons/ControllerIcons.gd
+++ b/addons/controller_icons/ControllerIcons.gd
@@ -268,8 +268,8 @@ func get_matching_event(path: String, input_type: InputType = _last_input_type, 
 					# Use the first device specific mapping if there is one.
 					if event.device == controller:
 						return event
-					# Otherwise ignore the device and use the first mapping.
-					elif fallback == null:
+					# Otherwise use the first "all devices" mapping.
+					elif fallback == null and event.device == -1:
 						fallback = event
 
 	return fallback

--- a/addons/controller_icons/ControllerIcons.gd
+++ b/addons/controller_icons/ControllerIcons.gd
@@ -1,7 +1,7 @@
 @tool
 extends Node
 
-signal input_type_changed(input_type: InputType)
+signal input_type_changed(input_type: InputType, controller: int)
 
 enum InputType {
 	KEYBOARD_MOUSE, ## The input is from the keyboard and/or mouse.
@@ -18,6 +18,7 @@ var _cached_icons := {}
 var _custom_input_actions := {}
 
 var _last_input_type : InputType
+var _last_controller : int
 var _settings : ControllerSettings
 var _base_extension := "png"
 
@@ -71,9 +72,10 @@ var _builtin_keys := [
 	"input/ui_up",
 ]
 
-func _set_last_input_type(__last_input_type):
+func _set_last_input_type(__last_input_type, __last_controller):
 	_last_input_type = __last_input_type
-	emit_signal("input_type_changed", _last_input_type)
+	_last_controller = __last_controller
+	emit_signal("input_type_changed", _last_input_type, __last_controller)
 
 func _enter_tree():
 	if Engine.is_editor_hint():
@@ -116,19 +118,22 @@ func _ready():
 	await get_tree().process_frame
 	# Set input type to what's likely being used currently
 	if Input.get_connected_joypads().is_empty():
-		_set_last_input_type(InputType.KEYBOARD_MOUSE)
+		_set_last_input_type(InputType.KEYBOARD_MOUSE, -1)
 	else:
-		_set_last_input_type(InputType.CONTROLLER)
+		_set_last_input_type(InputType.CONTROLLER, Input.get_connected_joypads().front())
 
 func _on_joy_connection_changed(device, connected):
-	if device == 0:
-		if connected:
-			_set_last_input_type(InputType.CONTROLLER)
+	if connected:
+		_set_last_input_type(InputType.CONTROLLER, device)
+	else:
+		if Input.get_connected_joypads().is_empty():
+			_set_last_input_type(InputType.KEYBOARD_MOUSE, -1)
 		else:
-			_set_last_input_type(InputType.KEYBOARD_MOUSE)
+			_set_last_input_type(InputType.CONTROLLER, Input.get_connected_joypads().front())
 
 func _input(event: InputEvent):
 	var input_type = _last_input_type
+	var controller = _last_controller
 	match event.get_class():
 		"InputEventKey", "InputEventMouseButton":
 			input_type = InputType.KEYBOARD_MOUSE
@@ -137,11 +142,13 @@ func _input(event: InputEvent):
 				input_type = InputType.KEYBOARD_MOUSE
 		"InputEventJoypadButton":
 			input_type = InputType.CONTROLLER
+			controller = event.device
 		"InputEventJoypadMotion":
 			if abs(event.axis_value) > _settings.joypad_deadzone:
 				input_type = InputType.CONTROLLER
-	if input_type != _last_input_type:
-		_set_last_input_type(input_type)
+				controller = event.device
+	if input_type != _last_input_type or controller != _last_controller:
+		_set_last_input_type(input_type, controller)
 
 func _test_mouse_velocity(relative_vec: Vector2):
 	if _t > _MOUSE_VELOCITY_DELTA:
@@ -164,12 +171,15 @@ func _add_custom_input_action(input_action: String, data: Dictionary):
 
 func refresh():
 	# All it takes is to signal icons to refresh paths
-	emit_signal("input_type_changed", _last_input_type)
+	emit_signal("input_type_changed", _last_input_type, _last_controller)
 
-func parse_path(path: String, input_type = _last_input_type) -> Texture:
+func get_joypad_type(controller: int = _last_controller) -> ControllerSettings.Devices:
+	return Mapper._get_joypad_type(controller, _settings.joypad_fallback)
+
+func parse_path(path: String, input_type = _last_input_type, last_controller = _last_controller) -> Texture:
 	if typeof(input_type) == TYPE_NIL:
 		return null
-	var root_paths := _expand_path(path, input_type)
+	var root_paths := _expand_path(path, input_type, last_controller)
 	for root_path in root_paths:
 		if _load_icon(root_path):
 			continue
@@ -202,16 +212,16 @@ func parse_event_modifiers(event: InputEvent) -> Array[Texture]:
 				modifiers.push_back("key/win")
 
 	for modifier in modifiers:
-		for icon_path in _expand_path(modifier, InputType.KEYBOARD_MOUSE):
+		for icon_path in _expand_path(modifier, InputType.KEYBOARD_MOUSE, -1):
 			if _load_icon(icon_path) == OK:
 				icons.push_back(_cached_icons[icon_path])
 
 	return icons
 
-func parse_path_to_tts(path: String, input_type: int = _last_input_type) -> String:
+func parse_path_to_tts(path: String, input_type: int = _last_input_type, controller: int = _last_controller) -> String:
 	if input_type == null:
 		return ""
-	var tts = _convert_path_to_asset_file(path, input_type)
+	var tts = _convert_path_to_asset_file(path, input_type, controller)
 	return _convert_asset_file_to_tts(tts.get_basename().get_file())
 
 func parse_event(event: InputEvent) -> Texture:
@@ -240,13 +250,14 @@ func get_path_type(path: String) -> PathType:
 	else:
 		return PathType.SPECIFIC_PATH
 
-func get_matching_event(path: String, input_type: InputType = _last_input_type) -> InputEvent:
+func get_matching_event(path: String, input_type: InputType = _last_input_type, controller: int = _last_controller) -> InputEvent:
 	var events : Array
 	if _custom_input_actions.has(path):
 		events = _custom_input_actions[path]
 	else:
 		events = InputMap.action_get_events(path)
 
+	var fallback = null
 	for event in events:
 		match event.get_class():
 			"InputEventKey", "InputEventMouse", "InputEventMouseMotion", "InputEventMouseButton":
@@ -254,10 +265,14 @@ func get_matching_event(path: String, input_type: InputType = _last_input_type) 
 					return event
 			"InputEventJoypadButton", "InputEventJoypadMotion":
 				if input_type == InputType.CONTROLLER:
-					return event
-	return null
+					if event.device == controller:
+						return event
+					elif fallback == null:
+						fallback = event
 
-func _expand_path(path: String, input_type: int) -> Array:
+	return fallback
+
+func _expand_path(path: String, input_type: int, controller: int) -> Array:
 	var paths := []
 	var base_paths := [
 		_settings.custom_asset_dir + "/",
@@ -266,20 +281,20 @@ func _expand_path(path: String, input_type: int) -> Array:
 	for base_path in base_paths:
 		if base_path.is_empty():
 			continue
-		base_path += _convert_path_to_asset_file(path, input_type)
+		base_path += _convert_path_to_asset_file(path, input_type, controller)
 
 		paths.push_back(base_path + "." + _base_extension)
 	return paths
 
-func _convert_path_to_asset_file(path: String, input_type: int) -> String:
+func _convert_path_to_asset_file(path: String, input_type: int, controller: int) -> String:
 	match get_path_type(path):
 		PathType.INPUT_ACTION:
-			var event := get_matching_event(path, input_type)
+			var event := get_matching_event(path, input_type, controller)
 			if event:
 				return _convert_event_to_path(event)
 			return path
 		PathType.JOYPAD_PATH:
-			return Mapper._convert_joypad_path(path, _settings.joypad_fallback)
+			return Mapper._convert_joypad_path(path, controller, _settings.joypad_fallback)
 		PathType.SPECIFIC_PATH, _:
 			return path
 
@@ -349,9 +364,9 @@ func _convert_event_to_path(event: InputEvent):
 	elif event is InputEventMouseButton:
 		return _convert_mouse_button_to_path(event.button_index)
 	elif event is InputEventJoypadButton:
-		return _convert_joypad_button_to_path(event.button_index)
+		return _convert_joypad_button_to_path(event.button_index, event.device)
 	elif event is InputEventJoypadMotion:
-		return _convert_joypad_motion_to_path(event.axis)
+		return _convert_joypad_motion_to_path(event.axis, event.device)
 
 func _convert_key_to_path(scancode: int):
 	match scancode:
@@ -563,7 +578,7 @@ func _convert_mouse_button_to_path(button_index: int):
 		_:
 			return "mouse/sample"
 
-func _convert_joypad_button_to_path(button_index: int):
+func _convert_joypad_button_to_path(button_index: int, controller: int):
 	var path
 	match button_index:
 		JOY_BUTTON_A:
@@ -600,9 +615,9 @@ func _convert_joypad_button_to_path(button_index: int):
 			path = "joypad/share"
 		_:
 			return ""
-	return Mapper._convert_joypad_path(path, _settings.joypad_fallback)
+	return Mapper._convert_joypad_path(path, controller, _settings.joypad_fallback)
 
-func _convert_joypad_motion_to_path(axis: int):
+func _convert_joypad_motion_to_path(axis: int, controller: int):
 	var path : String
 	match axis:
 		JOY_AXIS_LEFT_X, JOY_AXIS_LEFT_Y:
@@ -615,7 +630,7 @@ func _convert_joypad_motion_to_path(axis: int):
 			path = "joypad/rt"
 		_:
 			return ""
-	return Mapper._convert_joypad_path(path, _settings.joypad_fallback)
+	return Mapper._convert_joypad_path(path, controller, _settings.joypad_fallback)
 
 func _load_icon(path: String) -> int:
 	if _cached_icons.has(path): return OK

--- a/addons/controller_icons/Mapper.gd
+++ b/addons/controller_icons/Mapper.gd
@@ -1,8 +1,8 @@
 extends Node
 class_name ControllerMapper
 
-func _convert_joypad_path(path: String, fallback) -> String:
-	match _get_joypad_type(fallback):
+func _convert_joypad_path(path: String, device: int, fallback: ControllerSettings.Devices) -> String:
+	match _get_joypad_type(device, fallback):
 		ControllerSettings.Devices.LUNA:
 			return _convert_joypad_to_luna(path)
 		ControllerSettings.Devices.PS3:
@@ -32,8 +32,16 @@ func _convert_joypad_path(path: String, fallback) -> String:
 		_:
 			return ""
 
-func _get_joypad_type(fallback):
-	var controller_name = Input.get_joy_name(0)
+func _get_joypad_type(device, fallback):
+	var available = Input.get_connected_joypads()
+	if available.is_empty():
+		return fallback;
+	if !available.has(device):
+		device = ControllerIcons._last_controller
+	if !available.has(device):
+		device = available.front();
+
+	var controller_name = Input.get_joy_name(device)
 	if "Luna Controller" in controller_name:
 		return ControllerSettings.Devices.LUNA
 	elif "PS3 Controller" in controller_name:

--- a/addons/controller_icons/Mapper.gd
+++ b/addons/controller_icons/Mapper.gd
@@ -35,11 +35,13 @@ func _convert_joypad_path(path: String, device: int, fallback: ControllerSetting
 func _get_joypad_type(device, fallback):
 	var available = Input.get_connected_joypads()
 	if available.is_empty():
-		return fallback;
-	if !available.has(device):
+		return fallback
+	# If the requested joypad is not on the connected joypad list, try using the last known connected joypad
+	if not device in available:
 		device = ControllerIcons._last_controller
-	if !available.has(device):
-		device = available.front();
+	# If that fails too, then use whatever joypad we have connected right now
+	if not device in available:
+		device = available.front()
 
 	var controller_name = Input.get_joy_name(device)
 	if "Luna Controller" in controller_name:

--- a/addons/controller_icons/objects/Button.gd
+++ b/addons/controller_icons/objects/Button.gd
@@ -23,18 +23,18 @@ func _get_configuration_warnings():
 @export_enum("Both", "Keyboard/Mouse", "Controller") var show_only : int = 0:
 	set(_show_only):
 		show_only = _show_only
-		_on_input_type_changed(ControllerIcons._last_input_type)
+		_on_input_type_changed(ControllerIcons._last_input_type, ControllerIcons._last_controller)
 
 @export_enum("None", "Keyboard/Mouse", "Controller") var force_type : int = 0:
 	set(_force_type):
 		force_type = _force_type
-		_on_input_type_changed(ControllerIcons._last_input_type)
+		_on_input_type_changed(ControllerIcons._last_input_type, ControllerIcons._last_controller)
 
 func _ready():
 	ControllerIcons.input_type_changed.connect(_on_input_type_changed)
 	self.path = path
 
-func _on_input_type_changed(input_type):
+func _on_input_type_changed(input_type, controller):
 	if show_only == 0 or \
 		(show_only == 1 and input_type == ControllerIcons.InputType.KEYBOARD_MOUSE) or \
 		(show_only == 2 and input_type == ControllerIcons.InputType.CONTROLLER):
@@ -44,6 +44,6 @@ func _on_input_type_changed(input_type):
 
 func get_tts_string() -> String:
 	if force_type:
-		return ControllerIcons.parse_path_to_tts(path, force_type - 1)
+		return ControllerIcons.parse_path_to_tts(path, force_type - 1, ControllerIcons._last_controller)
 	else:
 		return ControllerIcons.parse_path_to_tts(path)

--- a/addons/controller_icons/objects/ControllerIconTexture.gd
+++ b/addons/controller_icons/objects/ControllerIconTexture.gd
@@ -181,7 +181,7 @@ func _load_texture_path():
 func _init():
 	ControllerIcons.input_type_changed.connect(_on_input_type_changed)
 
-func _on_input_type_changed(input_type: int):
+func _on_input_type_changed(input_type: int, controller: int):
 	_load_texture_path()
 
 #region "Draw functions"

--- a/addons/controller_icons/objects/Sprite.gd
+++ b/addons/controller_icons/objects/Sprite.gd
@@ -23,18 +23,18 @@ func _get_configuration_warnings():
 @export_enum("Both", "Keyboard/Mouse", "Controller") var show_only : int = 0:
 	set(_show_only):
 		show_only = _show_only
-		_on_input_type_changed(ControllerIcons._last_input_type)
+		_on_input_type_changed(ControllerIcons._last_input_type, ControllerIcons._last_controller)
 
 @export_enum("None", "Keyboard/Mouse", "Controller") var force_type : int = 0:
 	set(_force_type):
 		force_type = _force_type
-		_on_input_type_changed(ControllerIcons._last_input_type)
+		_on_input_type_changed(ControllerIcons._last_input_type, ControllerIcons._last_controller)
 
 func _ready():
 	ControllerIcons.input_type_changed.connect(_on_input_type_changed)
 	self.path = path
 
-func _on_input_type_changed(input_type):
+func _on_input_type_changed(input_type, controller):
 	if show_only == 0 or \
 		(show_only == 1 and input_type == ControllerIcons.InputType.KEYBOARD_MOUSE) or \
 		(show_only == 2 and input_type == ControllerIcons.InputType.CONTROLLER):

--- a/addons/controller_icons/objects/Sprite3D.gd
+++ b/addons/controller_icons/objects/Sprite3D.gd
@@ -23,18 +23,18 @@ func _get_configuration_warnings():
 @export_enum("Both", "Keyboard/Mouse", "Controller") var show_only := 0:
 	set(_show_only):
 		show_only = _show_only
-		_on_input_type_changed(ControllerIcons._last_input_type)
+		_on_input_type_changed(ControllerIcons._last_input_type, ControllerIcons._last_controller)
 
 @export_enum("None", "Keyboard/Mouse", "Controller") var force_type : int = 0:
 	set(_force_type):
 		force_type = _force_type
-		_on_input_type_changed(ControllerIcons._last_input_type)
+		_on_input_type_changed(ControllerIcons._last_input_type, ControllerIcons._last_controller)
 
 func _ready():
 	ControllerIcons.input_type_changed.connect(_on_input_type_changed)
 	self.path = path
 
-func _on_input_type_changed(input_type):
+func _on_input_type_changed(input_type, controller):
 	if show_only == 0 or \
 		(show_only == 1 and input_type == ControllerIcons.InputType.KEYBOARD_MOUSE) or \
 		(show_only == 2 and input_type == ControllerIcons.InputType.CONTROLLER):

--- a/addons/controller_icons/objects/TextureRect.gd
+++ b/addons/controller_icons/objects/TextureRect.gd
@@ -24,12 +24,12 @@ func _get_configuration_warnings():
 @export_enum("Both", "Keyboard/Mouse", "Controller") var show_only : int = 0:
 	set(_show_only):
 		show_only = _show_only
-		_on_input_type_changed(ControllerIcons._last_input_type)
+		_on_input_type_changed(ControllerIcons._last_input_type, ControllerIcons._last_controller)
 
 @export_enum("None", "Keyboard/Mouse", "Controller") var force_type : int = 0:
 	set(_force_type):
 		force_type = _force_type
-		_on_input_type_changed(ControllerIcons._last_input_type)
+		_on_input_type_changed(ControllerIcons._last_input_type, ControllerIcons._last_controller)
 
 @export var max_width : int = 40:
 	set(_max_width):
@@ -50,7 +50,7 @@ func _ready():
 	self.path = path
 	self.max_width = max_width
 
-func _on_input_type_changed(input_type):
+func _on_input_type_changed(input_type, controller):
 	if show_only == 0 or \
 		(show_only == 1 and input_type == ControllerIcons.InputType.KEYBOARD_MOUSE) or \
 		(show_only == 2 and input_type == ControllerIcons.InputType.CONTROLLER):


### PR DESCRIPTION
The current logic always uses the icons from the first controller. This PR changes the behavior to use the most recently used/connected controller. If it is no longer connected, then it falls back to the first controller (old logic).

When mapping actions to buttons, it uses the mapping for that specific controller. If there is no such mapping, it falls back to the first one it finds (old logic).

This helps in various situations:
- Multiple controllers of different types are connected at the same time (currently uses icons for the first controller).
- A new controller is connected before the old controller is disconnected (currently uses fallback icons).
- Godot incorrectly detects some hardware as joypad and it ends up before the first "real" controller (for example wacom drawing tabled+pen as joypad 0+1, results in fallback icons).
- An action is mapped differently on different controllers (currently takes the button for the first action it finds). For example if a game wants to swap A/B only on Nintendo controllers.

It should also work correctly when something like #58 is implemented. I wasn't sure about the best way to expose it and don't need it myself so I didn't implement it yet.