### PR TITLE
Ensure texture loading happens on the main thread

### DIFF
--- a/addons/controller_icons/objects/ControllerIconTexture.gd
+++ b/addons/controller_icons/objects/ControllerIconTexture.gd
@@ -160,7 +160,7 @@ func _reload_resource():
 	_dirty = true
 	emit_changed()
 
-func _load_texture_path_main_thread():
+func _load_texture_path_impl():
 	var textures : Array[Texture2D] = []
 	if ControllerIcons.is_node_ready() and _can_be_shown():
 		var input_type = ControllerIcons._last_input_type if force_type == ForceType.NONE else force_type - 1
@@ -174,9 +174,12 @@ func _load_texture_path_main_thread():
 func _load_texture_path():
 	# Ensure loading only occurs on the main thread
 	if OS.get_thread_caller_id() != OS.get_main_thread_id():
-		_load_texture_path_main_thread.call_deferred()
+		# In Godot 4.3, call_deferred no longer makes this function
+		# execute on the main thread due to changes in resource loading.
+		# To ensure this, we instead rely on ControllerIcons for this
+		ControllerIcons._defer_texture_load(_load_texture_path_impl)
 	else:
-		_load_texture_path_main_thread()
+		_load_texture_path_impl()
 
 func _init():
 	ControllerIcons.input_type_changed.connect(_on_input_type_changed)


### PR DESCRIPTION
Fixes #101.

Godot 4.3 had a core change with multi-threaded resource loading. This now occurs in a thread, and `call_deferred` is no longer a viable "hack" to ensure it runs on the main thread. To ensure this, such scenarios were changed to depend on the `ControllerIcons` singleton for ensuring a function call is executed on the main thread.

@plink-plonk-will this is essentially the same approach of https://github.com/rsubtil/controller_icons/pull/96, so I've added you as a co-author. I only decided to simplify it by keeping the logic on the texture icon code, keeping the singleton side as simple as possible.