### PR TITLE
Fix icons not remapping if scene tree is paused

### DIFF
--- a/addons/controller_icons/ControllerIcons.gd
+++ b/addons/controller_icons/ControllerIcons.gd
@@ -78,6 +78,7 @@ func _set_last_input_type(__last_input_type, __last_controller):
 	emit_signal("input_type_changed", _last_input_type, _last_controller)
 
 func _enter_tree():
+	process_mode = Node.PROCESS_MODE_ALWAYS
 	if Engine.is_editor_hint():
 		_parse_input_actions()
 


### PR DESCRIPTION
Fixes #102

Ensures the `ControllerIcons` is processed always, to also work when the game is paused (which is typically implemented through SceneTree's `paused` property)