### PR TITLE
Fix remapping to empty input type generating errors for 3D textures

### DIFF
--- a/addons/controller_icons/objects/ControllerIconTexture.gd
+++ b/addons/controller_icons/objects/ControllerIconTexture.gd
@@ -167,7 +167,9 @@ func _load_texture_path_main_thread():
 		if ControllerIcons.get_path_type(path) == ControllerIcons.PathType.INPUT_ACTION:
 			var event := ControllerIcons.get_matching_event(path, input_type)
 			textures.append_array(ControllerIcons.parse_event_modifiers(event))
-		textures.append(ControllerIcons.parse_path(path, input_type))
+		var tex := ControllerIcons.parse_path(path, input_type)
+		if tex:
+			textures.append(tex)
 	_textures = textures
 	_reload_resource()
 


### PR DESCRIPTION
If a given input action doesn't have an icon for the current input type, `null` is returned. This was being added to the texture array, becoming `[null]` and crashing on the texture stitching phase.

A null check was added to prevent this.