### PR TITLE
Fix controller mapping on Mac for DualSense and DUALSHOCK 4

### DIFF
--- a/addons/controller_icons/Mapper.gd
+++ b/addons/controller_icons/Mapper.gd
@@ -49,7 +49,7 @@ func _get_joypad_type(device, fallback):
 	elif "PS3 Controller" in controller_name:
 		return ControllerSettings.Devices.PS3
 	elif "PS4 Controller" in controller_name or \
-		"DualShock 4" in controller_name:
+		"DUALSHOCK 4" in controller_name:
 		return ControllerSettings.Devices.PS4
 	elif "PS5 Controller" in controller_name or \
 		"DualSense" in controller_name:

--- a/addons/controller_icons/Mapper.gd
+++ b/addons/controller_icons/Mapper.gd
@@ -48,9 +48,11 @@ func _get_joypad_type(device, fallback):
 		return ControllerSettings.Devices.LUNA
 	elif "PS3 Controller" in controller_name:
 		return ControllerSettings.Devices.PS3
-	elif "PS4 Controller" in controller_name:
+	elif "PS4 Controller" in controller_name or \
+		"DualShock 4" in controller_name:
 		return ControllerSettings.Devices.PS4
-	elif "PS5 Controller" in controller_name:
+	elif "PS5 Controller" in controller_name or \
+		"DualSense" in controller_name:
 		return ControllerSettings.Devices.PS5
 	elif "Stadia Controller" in controller_name:
 		return ControllerSettings.Devices.STADIA


### PR DESCRIPTION
Tested with DualSense and DUALSHOCK 4 controllers.

Side note: I also tested an Xbox Series controller, which is recognised as a Xbox Wireless Controller so currently maps to regular X-Box One, but this seems to be _okay_, as it's not that different.