### PR TITLE
Fix fallback event being null due to Godot's "all devices" value being changed

### DIFF
--- a/addons/controller_icons/ControllerIcons.gd
+++ b/addons/controller_icons/ControllerIcons.gd
@@ -282,7 +282,7 @@ func get_matching_event(path: String, input_type: InputType = _last_input_type, 
 					if event.device == controller:
 						return event
 					# Otherwise use the first "all devices" mapping.
-					elif fallback == null and event.device == -1:
+					elif fallback == null and event.device < 0:
 						fallback = event
 
 	return fallback


### PR DESCRIPTION
Closes #116.

https://github.com/godotengine/godot/pull/97707 changed the all devices mapping value from `-1` to `-3`. Although this was reverted due to being a breaking change, this has been deployed in some Godot versions, so to make this check more robust, it was changed to test for any negative values instead.