### PR TITLE
Prevent parsing of invalid/null events

### DIFF
--- a/addons/controller_icons/ControllerIcons.gd
+++ b/addons/controller_icons/ControllerIcons.gd
@@ -272,6 +272,8 @@ func get_matching_event(path: String, input_type: InputType = _last_input_type, 
 
 	var fallback = null
 	for event in events:
+		if not is_instance_valid(event): continue
+
 		match event.get_class():
 			"InputEventKey", "InputEventMouse", "InputEventMouseMotion", "InputEventMouseButton":
 				if input_type == InputType.KEYBOARD_MOUSE:


### PR DESCRIPTION
Fixes #122

It is possible for event information to contain invalid data, such as:
```
...
[input]

test_empty={
"deadzone": 0.5,
"events": null
}
test_list_empty={
"deadzone": 0.5,
"events": [null, Object(...)]
}
```

This adds a check to prevent further issues when the event is being parsed by the addon.