### PR TITLE
Add option to force a specified device index for rendering joypad icons

### DIFF
--- a/addons/controller_icons/ControllerIcons.gd
+++ b/addons/controller_icons/ControllerIcons.gd
@@ -310,7 +310,7 @@ func _convert_path_to_asset_file(path: String, input_type: int, controller: int)
 		PathType.INPUT_ACTION:
 			var event := get_matching_event(path, input_type, controller)
 			if event:
-				return _convert_event_to_path(event)
+				return _convert_event_to_path(event, controller)
 			return path
 		PathType.JOYPAD_PATH:
 			return Mapper._convert_joypad_path(path, controller, _settings.joypad_fallback)
@@ -374,7 +374,7 @@ func _convert_asset_file_to_tts(path: String) -> String:
 		_:
 			return path
 
-func _convert_event_to_path(event: InputEvent):
+func _convert_event_to_path(event: InputEvent, controller: int = _last_controller):
 	if event is InputEventKey:
 		# If this is a physical key, convert to localized scancode
 		if event.keycode == 0:
@@ -383,9 +383,9 @@ func _convert_event_to_path(event: InputEvent):
 	elif event is InputEventMouseButton:
 		return _convert_mouse_button_to_path(event.button_index)
 	elif event is InputEventJoypadButton:
-		return _convert_joypad_button_to_path(event.button_index, event.device)
+		return _convert_joypad_button_to_path(event.button_index, controller)
 	elif event is InputEventJoypadMotion:
-		return _convert_joypad_motion_to_path(event.axis, event.device)
+		return _convert_joypad_motion_to_path(event.axis, controller)
 
 func _convert_key_to_path(scancode: int):
 	match scancode:

--- a/addons/controller_icons/ControllerIcons.gd
+++ b/addons/controller_icons/ControllerIcons.gd
@@ -270,7 +270,7 @@ func get_matching_event(path: String, input_type: InputType = _last_input_type, 
 	else:
 		events = InputMap.action_get_events(path)
 
-	var fallback = null
+	var fallbacks = []
 	for event in events:
 		if not is_instance_valid(event): continue
 
@@ -283,11 +283,13 @@ func get_matching_event(path: String, input_type: InputType = _last_input_type, 
 					# Use the first device specific mapping if there is one.
 					if event.device == controller:
 						return event
-					# Otherwise use the first "all devices" mapping.
-					elif fallback == null and event.device < 0:
-						fallback = event
+					# Otherwise, we create a fallback prioritizing events with 'ALL_DEVICE' 
+					if event.device < 0: # All-device event
+						fallbacks.push_front(event)
+					else:
+						fallbacks.push_back(event)
 
-	return fallback
+	return fallbacks[0] if not fallbacks.is_empty() else null
 
 func _expand_path(path: String, input_type: int, controller: int) -> Array:
 	var paths := []

--- a/addons/controller_icons/objects/ControllerIconTexture.gd
+++ b/addons/controller_icons/objects/ControllerIconTexture.gd
@@ -84,10 +84,30 @@ enum ForceType {
 		force_type = _force_type
 		_load_texture_path()
 
+enum ForceDevice {
+	DEVICE_0,
+	DEVICE_1,
+	DEVICE_2,
+	DEVICE_3,
+	DEVICE_4,
+	DEVICE_5,
+	DEVICE_6,
+	DEVICE_7,
+	DEVICE_8,
+	DEVICE_9,
+	DEVICE_10,
+	DEVICE_11,
+	DEVICE_12,
+	DEVICE_13,
+	DEVICE_14,
+	DEVICE_15,
+	ANY # No device will be forced
+}
+
 ## Forces the icon to use the textures for the device connected at the specified index.
 ## For example, if a PlayStation 5 controller is connected at device_index 0,
 ## the icon will always show PlayStation 5 textures.
-@export var force_device: int = -1:
+@export var force_device: ForceDevice = ForceDevice.ANY:
 	set(_force_device):
 		force_device = _force_device
 		_load_texture_path()
@@ -175,7 +195,7 @@ func _load_texture_path_impl():
 		if ControllerIcons.get_path_type(path) == ControllerIcons.PathType.INPUT_ACTION:
 			var event := ControllerIcons.get_matching_event(path, input_type)
 			textures.append_array(ControllerIcons.parse_event_modifiers(event))
-		var target_device = force_device if force_device >= 0 else ControllerIcons._last_controller
+		var target_device = force_device if force_device != ForceDevice.ANY else ControllerIcons._last_controller
 		var tex := ControllerIcons.parse_path(path, input_type, target_device)
 		if tex:
 			textures.append(tex)


### PR DESCRIPTION
Closes #131

**Changes:**

- **New `force_device` Variable:** Added an exported variable `force_device` to specify a device in `_load_texture_path_impl`, passing it to `ControllerIcons.parse_path`.

- **Improved Event Matching Fallbacks:** Updated `get_matching_event` to prioritize "all-device-events", but now also consider other device slots. Previously, actions with events that had a different device set than `_last_controller` were ignored. This behaviour doesnt pair well with the new `force_device` feature.  Now, all `JoypadInputEvent` instances are considered, enhancing fallbacks when handling multiple controllers. But events with `All Device` are still prioritized in the fallback logic.

- **Path Conversion Update:** Modified `_convert_event_to_path` to utilize the controller index parameter from `_convert_path_to_asset_file`, ensuring `force_device` is respected even when the event's device differs.

**Impact:**

These updates improve multiplayer functionality and remapping menus, offering consistent icon rendering across controllers and robust support for control customization.

**Demonstration:**

Attached is a video showcasing these improvements in a local co-op game, highlighting seamless control remapping and device change.

Despite using a playstation 4 controller while remapping, I am remapping the controls of another player that uses a playstation 5 controller and the icons are still correctly shown depending on what controller is set in the upper left.

https://github.com/user-attachments/assets/b35ca308-d413-4cc5-b413-960a7dbe8db1

