### PR TITLE
Force a specific Controller Icon Style

### DIFF
--- a/addons/controller_icons/ControllerIcons.gd
+++ b/addons/controller_icons/ControllerIcons.gd
@@ -310,7 +310,7 @@ func _convert_path_to_asset_file(path: String, input_type: int, controller: int)
 		PathType.INPUT_ACTION:
 			var event := get_matching_event(path, input_type, controller)
 			if event:
-				return _convert_event_to_path(event)
+				return _convert_event_to_path(event, controller)
 			return path
 		PathType.JOYPAD_PATH:
 			return Mapper._convert_joypad_path(path, controller, _settings.joypad_fallback)
@@ -374,7 +374,7 @@ func _convert_asset_file_to_tts(path: String) -> String:
 		_:
 			return path
 
-func _convert_event_to_path(event: InputEvent):
+func _convert_event_to_path(event: InputEvent, controller: int = _last_controller):
 	if event is InputEventKey:
 		# If this is a physical key, convert to localized scancode
 		if event.keycode == 0:
@@ -383,9 +383,9 @@ func _convert_event_to_path(event: InputEvent):
 	elif event is InputEventMouseButton:
 		return _convert_mouse_button_to_path(event.button_index)
 	elif event is InputEventJoypadButton:
-		return _convert_joypad_button_to_path(event.button_index, event.device)
+		return _convert_joypad_button_to_path(event.button_index, controller)
 	elif event is InputEventJoypadMotion:
-		return _convert_joypad_motion_to_path(event.axis, event.device)
+		return _convert_joypad_motion_to_path(event.axis, controller)
 
 func _convert_key_to_path(scancode: int):
 	match scancode:

--- a/addons/controller_icons/ControllerIcons.gd
+++ b/addons/controller_icons/ControllerIcons.gd
@@ -186,7 +186,6 @@ func refresh():
 	# All it takes is to signal icons to refresh paths
 	emit_signal("input_type_changed", _last_input_type, _last_controller)
 
-## TODO: Can this be removed? Seems like its unused - greenpixels
 func get_joypad_type(controller: int = _last_controller) -> ControllerSettings.Devices:
 	return Mapper._get_joypad_type(controller, _settings.joypad_fallback)
 

--- a/addons/controller_icons/ControllerIcons.gd
+++ b/addons/controller_icons/ControllerIcons.gd
@@ -270,7 +270,7 @@ func get_matching_event(path: String, input_type: InputType = _last_input_type, 
 	else:
 		events = InputMap.action_get_events(path)
 
-	var fallback = null
+	var fallbacks = []
 	for event in events:
 		if not is_instance_valid(event): continue
 
@@ -283,11 +283,13 @@ func get_matching_event(path: String, input_type: InputType = _last_input_type, 
 					# Use the first device specific mapping if there is one.
 					if event.device == controller:
 						return event
-					# Otherwise use the first "all devices" mapping.
-					elif fallback == null and event.device < 0:
-						fallback = event
+					# Otherwise, we create a fallback prioritizing events with 'ALL_DEVICE' 
+					if event.device < 0: # All-device event
+						fallbacks.push_front(event)
+					else:
+						fallbacks.push_back(event)
 
-	return fallback
+	return fallbacks[0] if not fallbacks.is_empty() else null
 
 func _expand_path(path: String, input_type: int, controller: int) -> Array:
 	var paths := []

--- a/addons/controller_icons/Mapper.gd
+++ b/addons/controller_icons/Mapper.gd
@@ -1,8 +1,8 @@
 extends Node
 class_name ControllerMapper
 
-func _convert_joypad_path(path: String, device: int, fallback: ControllerSettings.Devices) -> String:
-	match _get_joypad_type(device, fallback):
+func _convert_joypad_path(path: String, device: int, fallback: ControllerSettings.Devices, force_controller_icon_style = ControllerSettings.Devices.NONE) -> String:
+	match _get_joypad_type(device, fallback, force_controller_icon_style):
 		ControllerSettings.Devices.LUNA:
 			return _convert_joypad_to_luna(path)
 		ControllerSettings.Devices.PS3:
@@ -32,7 +32,9 @@ func _convert_joypad_path(path: String, device: int, fallback: ControllerSetting
 		_:
 			return ""
 
-func _get_joypad_type(device, fallback):
+func _get_joypad_type(device, fallback, force_controller_icon_style):
+	if force_controller_icon_style != ControllerSettings.Devices.NONE:
+		return force_controller_icon_style
 	var available = Input.get_connected_joypads()
 	if available.is_empty():
 		return fallback

--- a/addons/controller_icons/Settings.gd
+++ b/addons/controller_icons/Settings.gd
@@ -15,7 +15,8 @@ enum Devices {
 	XBOX360,
 	XBOXONE,
 	XBOXSERIES,
-	STEAM_DECK
+	STEAM_DECK,
+	NONE
 }
 
 ## General addon settings

--- a/addons/controller_icons/Settings.gd
+++ b/addons/controller_icons/Settings.gd
@@ -3,6 +3,7 @@ extends Resource
 class_name ControllerSettings
 
 enum Devices {
+	NONE = -1,
 	LUNA,
 	OUYA,
 	PS3,
@@ -15,8 +16,7 @@ enum Devices {
 	XBOX360,
 	XBOXONE,
 	XBOXSERIES,
-	STEAM_DECK,
-	NONE
+	STEAM_DECK
 }
 
 ## General addon settings

--- a/addons/controller_icons/objects/ControllerIconTexture.gd
+++ b/addons/controller_icons/objects/ControllerIconTexture.gd
@@ -68,6 +68,22 @@ enum ShowMode {
 		show_mode = _show_mode
 		_load_texture_path()
 
+
+## Forces the icon to show a specific controller style, regardless of the
+## currently used controller type.
+##[br][br]
+## This will override force_device if set to a value other than NONE.
+##[br][br]
+## This is only relevant for paths using input actions, and has no effect on
+## other scenarios.
+
+
+
+@export var force_controller_icon_style: ControllerSettings.Devices = ControllerSettings.Devices.NONE:
+	set(_force_controller_icon_style):
+		force_controller_icon_style = _force_controller_icon_style
+		_load_texture_path()
+
 enum ForceType {
 	NONE, ## Icon will swap according to the used input method.
 	KEYBOARD_MOUSE, ## Icon will always show the keyboard/mouse action.
@@ -196,7 +212,7 @@ func _load_texture_path_impl():
 			var event := ControllerIcons.get_matching_event(path, input_type)
 			textures.append_array(ControllerIcons.parse_event_modifiers(event))
 		var target_device = force_device if force_device != ForceDevice.ANY else ControllerIcons._last_controller
-		var tex := ControllerIcons.parse_path(path, input_type, target_device)
+		var tex := ControllerIcons.parse_path(path, input_type, target_device, force_controller_icon_style)
 		if tex:
 			textures.append(tex)
 	_textures = textures

--- a/addons/controller_icons/objects/ControllerIconTexture.gd
+++ b/addons/controller_icons/objects/ControllerIconTexture.gd
@@ -84,10 +84,30 @@ enum ForceType {
 		force_type = _force_type
 		_load_texture_path()
 
+enum ForceDevice {
+	DEVICE_0,
+	DEVICE_1,
+	DEVICE_2,
+	DEVICE_3,
+	DEVICE_4,
+	DEVICE_5,
+	DEVICE_6,
+	DEVICE_7,
+	DEVICE_8,
+	DEVICE_9,
+	DEVICE_10,
+	DEVICE_11,
+	DEVICE_12,
+	DEVICE_13,
+	DEVICE_14,
+	DEVICE_15,
+	ANY # No device will be forced
+}
+
 ## Forces the icon to use the textures for the device connected at the specified index.
 ## For example, if a PlayStation 5 controller is connected at device_index 0,
 ## the icon will always show PlayStation 5 textures.
-@export var force_device: int = -1:
+@export var force_device: ForceDevice = ForceDevice.ANY:
 	set(_force_device):
 		force_device = _force_device
 		_load_texture_path()
@@ -175,7 +195,7 @@ func _load_texture_path_impl():
 		if ControllerIcons.get_path_type(path) == ControllerIcons.PathType.INPUT_ACTION:
 			var event := ControllerIcons.get_matching_event(path, input_type)
 			textures.append_array(ControllerIcons.parse_event_modifiers(event))
-		var target_device = force_device if force_device >= 0 else ControllerIcons._last_controller
+		var target_device = force_device if force_device != ForceDevice.ANY else ControllerIcons._last_controller
 		var tex := ControllerIcons.parse_path(path, input_type, target_device)
 		if tex:
 			textures.append(tex)

--- a/addons/controller_icons/objects/ControllerIconTexture.gd
+++ b/addons/controller_icons/objects/ControllerIconTexture.gd
@@ -77,8 +77,6 @@ enum ShowMode {
 ## This is only relevant for paths using input actions, and has no effect on
 ## other scenarios.
 
-
-
 @export var force_controller_icon_style: ControllerSettings.Devices = ControllerSettings.Devices.NONE:
 	set(_force_controller_icon_style):
 		force_controller_icon_style = _force_controller_icon_style


### PR DESCRIPTION
Closes #133 

I've added the option to set a specific icon style for ControllerIconTexture.

I exported a variable called `force_controller_icon_style` which uses the `ControllerSettings.Devices`-enum, but also added a `NONE` entry at the end of it - which is the default value for `force_controller_icon_style`. This way we don't have to maintain two enums for basically the same thing.

`force_controller_icon_style` will be passed down through all func calls until it reaches `_get_joypad_type`. In there, if `force_controller_icon_style` is anything other than `NONE`, we return that instead of executing the logic after it.

`force_device` and `force_controller_icon_style` naturally don't work together.
If `force_controller_icon_style` is anything other than `NONE` it will always overwrite `force_device`.


Also, while working on this:
@rsubtil In ControllerIcons is a `get_joypad_type` which calls Mapper._get_joypad_type - but I don't see that used anywhere. 
Can that be removed? I've added a TODO at that specific line in ControllerIcons.