### PR TITLE
Add last input type getter

### DIFF
--- a/addons/controller_icons/ControllerIcons.gd
+++ b/addons/controller_icons/ControllerIcons.gd
@@ -189,6 +189,9 @@ func refresh():
 func get_joypad_type(controller: int = _last_controller) -> ControllerSettings.Devices:
 	return Mapper._get_joypad_type(controller, _settings.joypad_fallback)
 
+func get_last_input_type() -> InputType:
+  return _last_input_type
+
 func parse_path(path: String, input_type = _last_input_type, last_controller = _last_controller, forced_controller_icon_style = ControllerSettings.Devices.NONE) -> Texture:
 	if typeof(input_type) == TYPE_NIL:
 		return null

--- a/addons/controller_icons/ControllerIcons.gd
+++ b/addons/controller_icons/ControllerIcons.gd
@@ -190,7 +190,7 @@ func get_joypad_type(controller: int = _last_controller) -> ControllerSettings.D
 	return Mapper._get_joypad_type(controller, _settings.joypad_fallback)
 
 func get_last_input_type() -> InputType:
-  return _last_input_type
+	return _last_input_type
 
 func parse_path(path: String, input_type = _last_input_type, last_controller = _last_controller, forced_controller_icon_style = ControllerSettings.Devices.NONE) -> Texture:
 	if typeof(input_type) == TYPE_NIL:


### PR DESCRIPTION
For more complex custom nodes that use controller icons and have to set some things based on last input type, there's no "clean" way of getting the last input type.
While it's possible to set it manually by connecting to `input_type_changed` signal, getting the initial value via private `ControllerIcons._last_input_type` seems like a hack and makes me feel bad for writing that kind of code 🥲 

So, I've added a simple input type getter to ControllerIcons autoload.