### PR TITLE
Exit modifier texture load after first success

### DIFF
--- a/addons/controller_icons/ControllerIcons.gd
+++ b/addons/controller_icons/ControllerIcons.gd
@@ -231,6 +231,7 @@ func parse_event_modifiers(event: InputEvent) -> Array[Texture]:
 		for icon_path in _expand_path(modifier, InputType.KEYBOARD_MOUSE, -1):
 			if _load_icon(icon_path) == OK:
 				icons.push_back(_cached_icons[icon_path])
+				break
 
 	return icons
 


### PR DESCRIPTION
Fixes #139 

Currently, icons for modifier keys load all textures provided from the call to `_expand_path`, resulting in both custom and base textures being loaded, generating incorrect input hints. This PR stops loading icons for a given key after the first successful load, letting custom assets properly override base assets while still falling back on them as needed.