### PR TITLE
Add LICENSE to addon directory

### DIFF
--- a/addons/controller_icons/LICENSE
+++ b/addons/controller_icons/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Ricardo Subtil
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
In this PR, I've add a copy of the LICENSE to the `addons/controller_icons` to make it easier for users to include the LICENSE in their projects.

Typically, the contents of the addons directory is the only portion of the repo that is incorporated into user's projects. However, since this folder does not contain a copy of the LICENSE, in order to comply with the MIT license, user's would also need to make a separate copy of the LICENSE into their project. This change makes that inclusion easier.