### PR TITLE
Add C# fork link

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ Provides icons for all major controllers and keyboard/mouse actions, with an aut
 > [!IMPORTANT]
 > This is the Godot 4.x version. For the Godot 3.x version, check the [3.x branch](https://github.com/rsubtil/controller_icons/tree/3.x)
 
+> [!NOTE]
+> If you're using C#, there are currently some engine bugs affecting the addon's usage. For a C# version of the addon, check out [Jace Varlet's fork instead](https://github.com/jembawls/controller_icons_csharp).
+>
+> A special thanks to Jace for porting this addon to C#. Please check out [their work](https://linktr.ee/jembawls)!
+
 The minimum Godot version is 4.1.2 (stable).
 
 Download this repository and copy the `addons` folder to your project root directory.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 Provides icons for all major controllers and keyboard/mouse actions, with an automatic icon remapping system.
 
+> [!IMPORTANT]
 > This is the Godot 4.x version. For the Godot 3.x version, check the [3.x branch](https://github.com/rsubtil/controller_icons/tree/3.x)
 
 ## Features
@@ -36,6 +37,7 @@ Provides icons for all major controllers and keyboard/mouse actions, with an aut
 
 ## Installation
 
+> [!IMPORTANT]
 > This is the Godot 4.x version. For the Godot 3.x version, check the [3.x branch](https://github.com/rsubtil/controller_icons/tree/3.x)
 
 The minimum Godot version is 4.1.2 (stable).


### PR DESCRIPTION
Due to some specific C# bugs (https://github.com/rsubtil/controller_icons/issues/95), this addon sometimes fails to load when launching the project. A C# port was independently created by Jace Varlet, and with his permission, I've linked it here.

cc @jembawls