### PR TITLE
fix grab_focus() overrides to match godot 4.6 signature

### DIFF
--- a/addons/controller_icons/objects/path_selection/InputActionSelector.gd
+++ b/addons/controller_icons/objects/path_selection/InputActionSelector.gd
@@ -94,8 +94,8 @@ func set_default_actions_visibility(display: bool):
 	for item in items:
 		item.show_default = display or not item.is_default
 
-func grab_focus() -> void:
-	n_name_filter.grab_focus()
+func grab_focus(hide_focus: bool = false) -> void:
+	n_name_filter.grab_focus(hide_focus)
 
 
 func _on_builtin_action_button_toggled(toggled_on: bool) -> void:

--- a/addons/controller_icons/objects/path_selection/JoypadPathSelector.gd
+++ b/addons/controller_icons/objects/path_selection/JoypadPathSelector.gd
@@ -34,7 +34,7 @@ func get_icon_path() -> String:
 			return button.icon.path
 	return ""
 
-func grab_focus() -> void:
+func grab_focus(hide_focus: bool = false) -> void:
 	pass
 
 func _input(event):

--- a/addons/controller_icons/objects/path_selection/SpecificPathSelector.gd
+++ b/addons/controller_icons/objects/path_selection/SpecificPathSelector.gd
@@ -134,8 +134,8 @@ func get_icon_path() -> String:
 		return button.icon.path
 	return ""
 
-func grab_focus() -> void:
-	n_name_filter.grab_focus()
+func grab_focus(hide_focus: bool = false) -> void:
+	n_name_filter.grab_focus(hide_focus)
 
 
 func _on_base_asset_names_item_selected():


### PR DESCRIPTION
Updating a project that uses controller_icons to Godot 4.6 will trigger the following error - `Parse Error: The function signature doesn't match the parent. Parent signature is "grab_focus(bool = <default>) -> void"`

It's because `grab_focus` now has a default bool argument `hide_focus`, which I added to the affected files. Older versions shouldn't be affected. I tested this on a throwaway project with Godot 4.5.1 and Godot 4.3 on Linux, so this _should_ be fine.