### PR TITLE
Bump version to v3.1.6

### DIFF
--- a/addons/controller_icons/plugin.cfg
+++ b/addons/controller_icons/plugin.cfg
@@ -3,5 +3,5 @@
 name="Controller Icons"
 description="Provides icons for all major controllers and keyboard, with automatic icon remapping."
 author="rsubtil"
-version="3.1.5"
+version="3.1.6"
 script="plugin.gd"


### PR DESCRIPTION
Version v3.1.6 is now ready :tada:

There are no new features due to the incoming major release. This is only to fix a parse error on Godot v4.6.