### PR TITLE
Fix 3D icons not generating mipmaps

### DIFF
--- a/addons/controller_icons/objects/ControllerIconTexture.gd
+++ b/addons/controller_icons/objects/ControllerIconTexture.gd
@@ -412,6 +412,7 @@ func _stitch_texture():
 
 	_is_stitching_texture = false
 	_dirty = false
+	img.generate_mipmaps()
 	_texture_3d = ImageTexture.create_from_image(img)
 	emit_changed()
 


### PR DESCRIPTION
Closes #159.

The generated image had no mipmaps, and so Godot attempted to swap to those depending on angle and distance, which were just blank images.