### PR TITLE
Fix get_joypad_type() function not adding necessary controller style parameter

### DIFF
--- a/addons/controller_icons/ControllerIcons.gd
+++ b/addons/controller_icons/ControllerIcons.gd
@@ -187,7 +187,7 @@ func refresh():
 	emit_signal("input_type_changed", _last_input_type, _last_controller)
 
 func get_joypad_type(controller: int = _last_controller) -> ControllerSettings.Devices:
-	return Mapper._get_joypad_type(controller, _settings.joypad_fallback)
+	return Mapper._get_joypad_type(controller, _settings.joypad_fallback, ControllerSettings.Devices.NONE)
 
 func get_last_input_type() -> InputType:
 	return _last_input_type


### PR DESCRIPTION
Fixes #162

The public function in `ControllerIcons` was not changed to accomodate for the new `force_controller_icon_style` argument of the `Mapper`.