### PR TITLE
Fix icon fetched on invalid paths

### DIFF
--- a/addons/controller_icons/ControllerIcons.gd
+++ b/addons/controller_icons/ControllerIcons.gd
@@ -247,13 +247,14 @@ func parse_event(event: InputEvent) -> Texture:
 		return null
 
 	var base_paths := [
-		_settings.custom_asset_dir + "/",
-		"res://addons/controller_icons/assets/"
+		_settings.custom_asset_dir,
+		"res://addons/controller_icons/assets"
 	]
 	for base_path in base_paths:
+		base_path = base_path.simplify_path()
 		if base_path.is_empty():
 			continue
-		base_path += path + "." + _base_extension
+		base_path = base_path.path_join( "%s.%s" % [path, _base_extension] )
 		if _load_icon(base_path):
 			continue
 		return _cached_icons[base_path]


### PR DESCRIPTION
Fixes #168

Because of the trailing slash, there was always a non-empty path to test if no custom assets were specified. This resulted in a crash for the Nintendo Switch port of the engine.

This changes the mechanism to use more robust Godot file path APIs to mitigate such issues in the future. 