### PR TITLE
fix 4.7 return type error in _get_rid()

### DIFF
--- a/addons/controller_icons/objects/ControllerIconTexture.gd
+++ b/addons/controller_icons/objects/ControllerIconTexture.gd
@@ -427,9 +427,9 @@ func _get_rid():
 			# This results in a one-frame white texture being displayed, which is not ideal. Investigate later.
 			_stitch_texture()
 			if _is_stitching_texture:
-				return 0
+				return RID()
 		else:
-			return 0
+			return RID()
 	return _texture_3d.get_rid() if not _textures.is_empty() else 0
 
 #endregion

--- a/addons/controller_icons/objects/ControllerIconTexture.gd
+++ b/addons/controller_icons/objects/ControllerIconTexture.gd
@@ -430,6 +430,6 @@ func _get_rid():
 				return RID()
 		else:
 			return RID()
-	return _texture_3d.get_rid() if not _textures.is_empty() else 0
+	return _texture_3d.get_rid() if not _textures.is_empty() else RID()
 
 #endregion


### PR DESCRIPTION
After upgrading a project using the Controller Icons addon to 4.7, the `get_rid()` method of ControllerIconTexture gives the following error: `Cannot return value of type "int" because the function return type is "RID".` This has been fixed by returning `RID()` instead of `0`.